### PR TITLE
Add file-based webhook configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+src/config/webhooks.env
 src/server
 
 # CSV（Git未管理）

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ YouTubeのRSSを巡回し、カテゴリごとに Discord / Slack へ新着動�
 - Controller / Service / Repository のクリーン構成
 
 ## ディレクトリ
-src/config/          # app.yaml（カテゴリ→出力先／ENV名、レート、フィルタ）
+src/config/          # app.yaml（カテゴリ→出力先／ENV名、レート、フィルタ）, webhooks.env（Webhook実体、Git未管理）
 src/cmd/job/         # エントリポイント（RunOnceジョブ）
 src/internal/        # controller, service, repository, notifier, model, config, util
 src/src/csv/         # CSV置き場（Git未管理）
@@ -17,13 +17,15 @@ docs/                # 設計ドキュメント
 
 ## 前提
 - Go 1.24+
-- Webhook（Discord/Slack）のURLは GitHub Secrets 経由で注入
+- Webhook（Discord/Slack）のURLは src/config/webhooks.env に記載（Git未管理）
 
 ## セットアップ（ローカル）
 ```bash
 cd src
 go mod tidy
 mkdir -p src/csv
+# Webhook設定ファイルを作成
+cp config/webhooks.env.example config/webhooks.env
 # channels.csv / notified.csv を配置（Gitに含めない）
 go run ./cmd/job
 ```
@@ -31,7 +33,7 @@ go run ./cmd/job
 ## GitHub Actions（6時間ごと）
 
 - ワークフロー：.github/workflows/youtube-notify.yml
-- Secrets 例：DISCORD_WEBHOOK_TRAVEL, SLACK_WEBHOOK_NEWS, DISCORD_WEBHOOK_TECH
+- webhooks.env のキー例：DISCORD_WEBHOOK_TRAVEL, SLACK_WEBHOOK_NEWS, DISCORD_WEBHOOK_TECH
 
 ## CSV スキーマ
 ```channels.csv

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,14 @@
 - ストレージ：DB 不使用。通知済み管理・チャンネル定義は CSV（リポジトリ外・Git未管理）。
 - 出力：Discord / Slack の Webhook 両対応（カテゴリ単位で切り替え）。
 - フィード：YouTube RSS（APIキー不要）。
-- カテゴリ：travel, news, など任意。カテゴリ→出力先（Discord/Slack）および Webhook 環境変数名を config/app.yaml で定義。
+- カテゴリ：travel, news, など任意。カテゴリ→出力先（Discord/Slack）および Webhook キー名を config/app.yaml で定義。
 - 実行制御：レート制限のため、取得間隔・投稿間隔を設定値で制御。
 
 ## 非機能要件
 - 無料運用（GitHub Actions の無料枠想定、短時間ジョブ）。
 - 冪等性：同一 videoId の重複通知防止（notified.csv で管理）。
 - 可観測性：標準出力に JSON ライクなログ（成功/失敗件数、経過時間）。
-- セキュリティ：Webhook URL は GitHub Secrets で注入。config/app.yaml は URL 名（ENV名）マッピングのみを保持。
+- セキュリティ：Webhook URL は src/config/webhooks.env（Git未管理）に保存し、config/app.yaml はキー名のみを保持。
 
 ## 除外範囲（当面実施しない）
 - データベース永続化。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -59,8 +59,8 @@ YouTube RSS を巡回し、新着動画をカテゴリごとに Discord / Slack 
 
 
 ## 8. セキュリティ
-- Webhook は GitHub Secrets の環境変数から取得
-- `config/app.yaml` は ENV 名のみ保持
+- Webhook は Git未管理の `src/config/webhooks.env` から取得
+- `config/app.yaml` は Webhook キー名のみ保持
 
 
 ## 9. ログ仕様

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -13,7 +13,7 @@
 
 4. 設定管理
 - src/config/app.yaml にカテゴリ→出力先のマッピング、レート、フィルタ等を定義。
-- Webhook の実値は 環境変数（Secrets）でのみ注入。リポジトリ内に秘匿情報を置かない。
+- Webhook の実値は Git未管理の src/config/webhooks.env に記載。リポジトリ内に秘匿情報をコミットしない。
 
 5. CSV 運用
 - src/src/csv/ 配下の CSV は Git管理対象外。.gitignore にパスを含める。

--- a/docs/sequences/notify_mapping.md
+++ b/docs/sequences/notify_mapping.md
@@ -1,4 +1,4 @@
-# シーケンス — カテゴリ→出力先/ENV マッピング
+# シーケンス — カテゴリ→出力先/キー マッピング
 
 
 ```mermaid
@@ -6,16 +6,16 @@ sequenceDiagram
 autonumber
 participant Cfg as config/app.yaml
 participant NS as NotifyService
-participant Env as Environment
+participant Sec as webhooks.env
 participant WB as Webhook
 
 
 NS->>Cfg: category_to_output[category]
 Cfg-->>NS: "discord" or "slack"
 NS->>Cfg: category_to_env[category]
-Cfg-->>NS: ENV名（例: SLACK_WEBHOOK_NEWS）
-NS->>Env: getenv(ENV名)
-Env-->>NS: 実際のWebhook URL
+Cfg-->>NS: キー名（例: SLACK_WEBHOOK_NEWS）
+NS->>Sec: lookup(キー名)
+Sec-->>NS: 実際のWebhook URL
 NS->>WB: POST (payload)
 WB-->>NS: 2xx/4xx/5xx
 ```

--- a/src/config/app.yaml
+++ b/src/config/app.yaml
@@ -1,9 +1,10 @@
 default_output: "discord"  # 今回はDiscordのみ
+webhook_file: "config/webhooks.env"
 category_to_output:
   travel: "discord"
   news:   "discord"
 category_to_env:
-  travel: "DISCORD_WEBHOOK_TRAVEL"  # 実値は環境変数/Secretsで注入
+  travel: "DISCORD_WEBHOOK_TRAVEL"  # 実値は webhooks.env で管理
   news:   "DISCORD_WEBHOOK_NEWS"
 rate_limit:
   fetch_sleep_ms: 1200

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -12,6 +12,7 @@ type AppConfig struct {
 	DefaultOutput    string
 	CategoryToOutput map[string]string
 	CategoryToEnv    map[string]string
+	WebhookFile      string
 	RateLimit        struct {
 		FetchSleepMS int
 		PostSleepMS  int
@@ -97,6 +98,8 @@ func applyTopLevel(cfg *AppConfig, key, value string) error {
 		cfg.DefaultOutput = value
 	case "timezone":
 		cfg.Timezone = value
+	case "webhook_file":
+		cfg.WebhookFile = value
 	default:
 		return nil
 	}

--- a/src/config/webhook.go
+++ b/src/config/webhook.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LoadWebhookFile loads webhook secrets from a simple KEY=VALUE formatted file.
+func LoadWebhookFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	secrets := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := parseSecretLine(line)
+		if !ok {
+			return nil, fmt.Errorf("invalid webhook secret line: %s", line)
+		}
+		secrets[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return secrets, nil
+}
+
+func parseSecretLine(line string) (string, string, bool) {
+	idx := strings.Index(line, "=")
+	if idx <= 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(line[:idx])
+	value := strings.TrimSpace(line[idx+1:])
+	if key == "" {
+		return "", "", false
+	}
+	if c := strings.Index(value, "#"); c != -1 {
+		value = strings.TrimSpace(value[:c])
+	}
+	if value == "" {
+		return "", "", false
+	}
+	return key, trimQuotes(value), true
+}

--- a/src/config/webhooks.env.example
+++ b/src/config/webhooks.env.example
@@ -1,0 +1,4 @@
+# Discord webhook URLs for each category. Duplicate this file to src/config/webhooks.env
+# and fill in the actual webhook URLs. Keep the real file out of version control.
+DISCORD_WEBHOOK_TRAVEL="https://discord.com/api/webhooks/xxxxxxxxxxxxxxxx"
+DISCORD_WEBHOOK_NEWS="https://discord.com/api/webhooks/yyyyyyyyyyyyyyyy"


### PR DESCRIPTION
## Summary
- allow configuring a secrets file for webhook URLs in `app.yaml` and load it at startup
- update the notify service to use direct webhook URLs instead of environment variables
- document the new `webhooks.env` workflow and add an example secrets file while ignoring the real one

## Testing
- go test ./... *(hangs in container, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_6906f8032a8c8327af313455e1b9561d