### PR TITLE
Clarify JST schedule for notifier workflow

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -2,8 +2,9 @@ name: Notify subscribers
 
 on:
   schedule:
-    # 09:00, 20:00
-    - cron: '0 0,11 * * *'
+    # 09:00, 20:00 JST
+    - cron: '0 9,20 * * *'
+      timezone: Asia/Tokyo
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- update the scheduled trigger to run at 09:00 and 20:00 Japan time
- explicitly set the workflow timezone to Asia/Tokyo for clarity

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691133f014488327aa4fd4878e8df87d)